### PR TITLE
Plugins!

### DIFF
--- a/backend/.env_example
+++ b/backend/.env_example
@@ -18,4 +18,7 @@ DENIED_USERS="*"
 SESSION_SECRET=""
 ENCRYPTION_KEY=""
 
+# Fill in your plugins constants
+# IMGBB_API_KEY=""
+
 # note: podman users should remove the double quotes around values for compatibility with podman

--- a/backend/controller/server.mjs
+++ b/backend/controller/server.mjs
@@ -4,6 +4,7 @@ const file = await import(`${backend}/model/file.mjs`);
 const sql = await import(`${backend}/model/sql.mjs`);
 const user = await import(`${backend}/model/user.mjs`);
 const utils = await import(`${backend}/model/utils.mjs`);
+const plugins = await import(`${backend}/model/plugins.mjs`);
 
 import * as socket_io_server from "socket.io";
 import express from "express";
@@ -14,6 +15,8 @@ import passport_reddit from "passport-reddit";
 import crypto from "crypto";
 import filesystem from "fs";
 import fileupload from "express-fileupload";
+
+plugins.validatePlugins();
 
 const app = express();
 const server = http.createServer(app);

--- a/backend/model/plugins.mjs
+++ b/backend/model/plugins.mjs
@@ -1,0 +1,28 @@
+import * as userPlugins from '../plugins/index.mjs';
+
+let pluginsArray = [];
+
+function getPlugins() {
+	if (pluginsArray.length === 0) {
+		Object.keys(userPlugins).forEach((key) => {
+			pluginsArray.push(userPlugins[key].plugin)
+		})
+	}
+	return pluginsArray;
+}
+
+function validatePlugins() {
+	for (const plugin of getPlugins()) {
+		if (!plugin.can('getId') ||
+			!plugin.can('receiveItem') ||
+			!plugin.can('receiveUserItem') ||
+			!plugin.can('getAvailableConfig')) {
+				throw new Error(`A plugin is not formatted properly`);
+			}
+	}
+}
+
+export {
+	getPlugins,
+	validatePlugins
+}

--- a/backend/model/sql.mjs
+++ b/backend/model/sql.mjs
@@ -317,6 +317,30 @@ async function insert_data(username, data) {
 	await transaction(prepared_statements);
 }
 
+async function get_items(ids) {
+	if (typeof ids === 'string' || ids instanceof String) {
+		ids = ids.split(',');
+	}
+	if (!Array.isArray(ids)) {
+		throw new Error('Expected array of strings');
+	}
+
+	let count = 0;
+	let query = "select * from item where id in (";
+	query += ids.reduce((prev) => {
+		return prev + `$${count++},`;
+	}, '');
+	query = query.replace(/,$/, '');
+	query += ')';
+
+	let prepared_statement = {
+		text: query,
+		values: ids
+	};
+
+	return await query(prepared_statement);
+}
+
 async function get_data(username, filter, item_count, offset) {
 	const data = {
 		items: {},
@@ -638,6 +662,7 @@ export {
 	purge_user,
 	get_all_non_purged_users,
 	insert_data,
+	get_items,
 	get_data,
 	get_placeholder,
 	get_subs,

--- a/backend/model/user.mjs
+++ b/backend/model/user.mjs
@@ -5,11 +5,13 @@ const reddit = await import(`${backend}/model/reddit.mjs`);
 const cryptr = await import(`${backend}/model/cryptr.mjs`);
 const logger = await import(`${backend}/model/logger.mjs`);
 const utils = await import(`${backend}/model/utils.mjs`);
+const plugins = await import(`${backend}/model/plugins.mjs`);
 
 let update_all_completed = null;
 
 const usernames_to_socket_ids = {};
 const socket_ids_to_usernames = {};
+const categories = ["saved", "created", "upvoted", "downvoted", "hidden", "awarded"];
 
 class User {
 	constructor(username, refresh_token, dummy=false) {
@@ -150,6 +152,8 @@ class User {
 				};
 
 				this.new_data.category_item_ids[category].add(item.id);
+
+				this.new_data.objects.set(item.id, item);
 
 				this.sub_icon_urls_to_get.add(item.subreddit_name_prefixed);
 			}
@@ -316,6 +320,7 @@ class User {
 		this.me = await this.requester.getMe();
 		
 		this.new_data = {
+			objects: new Map(),
 			items: {},
 			category_item_ids: {},
 			item_sub_icon_urls: {}
@@ -323,11 +328,9 @@ class User {
 		this.sub_icon_urls_to_get = new Set();
 		this.imported_fns_to_delete = new Set();
 
-		const categories = ["saved", "created", "upvoted", "downvoted", "hidden", "awarded"];
 		for (const category of categories) {
 			this.new_data.category_item_ids[category] = new Set();
 		}
-		categories.pop();
 
 		const s_promise = new Promise(async (resolve, reject) => {
 			try {
@@ -418,9 +421,12 @@ class User {
 		await Promise.all([s_promise, c_promise, u_promise, d_promise, h_promise, a_promise]);
 		await this.get_new_item_icon_urls();
 
+		let newItems = await this.getNewItems();
+
 		try {
 			await sql.insert_data(this.username, this.new_data);
 			await sql.delete_imported_fns([...(this.imported_fns_to_delete)]);
+			this.callPlugins(newItems);
 			(io ? io.to(socket_id).emit("update progress", ++progress, complete) : null);
 		} catch (err) {
 			console.error(err);
@@ -498,6 +504,37 @@ class User {
 			await sql.update_user(this.username, {
 				category_sync_info: JSON.stringify(this.category_sync_info)
 			});
+		}
+	}
+	async getNewItems() {
+		let ids = [];
+		this.new_data.objects.forEach((value) => ids.push(value.id));
+		let dbItems = await sql.get_items(ids);
+
+		let newItems = [];
+		this.new_data.objects.forEach((value) => {
+			if (dbItems.find(item => item.id == value.id) === undefined) newItems.push(value);
+		});
+		return newItems;
+	}
+	async callPlugins(newItems) {
+		for (const plugin of plugins.getPlugins()) {
+			newItems.forEach((post) => {
+				Promise.resolve(
+					plugin.receiveItem(post)
+					).then(() => {}).catch((error) => {
+					console.error(`Plugin "${plugin.getId()}" failed receiving item`, error);
+				});
+			});
+			for (const category of categories) {
+				for (const item of this.new_data.category_item_ids[category]) {
+					Promise.resolve(
+						plugin.receiveUserItem(this.username, category, this.new_data.objects.get(item), {})
+						).then(() => {}).catch((error) => {
+						console.error(`Plugin "${plugin.getId()}" failed receiving user item`, error);
+					});
+				}
+			}
 		}
 	}
 	async purge() {

--- a/backend/model/utils.mjs
+++ b/backend/model/utils.mjs
@@ -1,3 +1,11 @@
+
+Object.defineProperty(Object.prototype, 'can', {
+    enumerable: false,
+    value: function(method) {
+        return (typeof this[method] === 'function');
+    }
+});
+
 function now_epoch() {
 	const now_epoch = Math.floor(Date.now() / 1000);
 	return now_epoch;

--- a/backend/plugins/index.mjs
+++ b/backend/plugins/index.mjs
@@ -1,0 +1,6 @@
+// import * as imgbb from './imgbb.mjs';
+
+
+export {
+	// imgbb
+}


### PR DESCRIPTION
Created a base system to have plugins :D  

Plugins will be located in `backend/plugins`, they need to be added to the `index.mjs` file so expanse can read them.  
Comments with an example were included :P  

I required the plugins to have some functions that expanse will call at some point.  
The current ones are:
* `getId()` to identify the plugin (ideally would be unique for future usages)  
* `receiveItem(item)` for the plugin to process items that are saved in the DB, regardless of from which user it came from  
* `receiveUserItem(user, category, item, config)` for the plugin to process items of a user.  
* `getAvailableConfig()` for future usage to be able to template a config screen for the user.  

An example of how it works can be found in [my fork for ImgBB](https://github.com/QtFuta/expanse/blob/main/backend/plugins/imgbb.mjs) :3  

So, this is a base implementation, there is some stuff that I want to improve/implement:  
* Currently plugins will be called for all new items and for all users, there needs to be a way to let the user decide which items they want to let the plugin process.
This is where the uniqueness of `getId()` will be in play.  
* Allow users to configure the plugin, since in the example in my fork I'm only processing items that have been saved, but user might want to dynamically update this and would be different for each user.  
This is where `getAvailableConfig()` to get an object with the possible properties to configure plus possible values and more stuff to create a dynamic form for the user.  
Also in here the DB will need to be updated with a new table to store the plugin configuration for each user, then it'll be sent as the last parameter of `receiveUserItem`  


I need help with something! 😓   
In my fork I'm using SQLite, so can someone please test that the function `get_items(ids)` works well with postgres?